### PR TITLE
add index

### DIFF
--- a/sql/0_Schema.sql
+++ b/sql/0_Schema.sql
@@ -26,8 +26,9 @@ CREATE TABLE `isu_condition` (
   PRIMARY KEY(`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4;
 
-CREATE INDEX ix_isu_condition_jia_isu_uuid_timestamp ON isu_condition (jia_isu_uuid, timestamp DESC);
-CREATE INDEX `idx_jia_isu_uuid_and_timestamp` ON isu_condition (`jia_isu_uuid`, `timestamp`);
+CREATE INDEX idx_jia_isu_uuid_and_timestamp_desc ON isu_condition (jia_isu_uuid, timestamp DESC);
+CREATE INDEX idx_jia_isu_uuid_and_timestamp ON isu_condition (jia_isu_uuid, timestamp);
+
 
 CREATE TABLE `user` (
   `jia_user_id` VARCHAR(255) PRIMARY KEY,

--- a/sql/0_Schema.sql
+++ b/sql/0_Schema.sql
@@ -26,6 +26,9 @@ CREATE TABLE `isu_condition` (
   PRIMARY KEY(`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4;
 
+CREATE INDEX ix_isu_condition_jia_isu_uuid_timestamp ON isu_condition (jia_isu_uuid, timestamp DESC);
+CREATE INDEX `idx_jia_isu_uuid_and_timestamp` ON isu_condition (`jia_isu_uuid`, `timestamp`);
+
 CREATE TABLE `user` (
   `jia_user_id` VARCHAR(255) PRIMARY KEY,
   `created_at` DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)

--- a/sql/0_Schema.sql
+++ b/sql/0_Schema.sql
@@ -26,8 +26,8 @@ CREATE TABLE `isu_condition` (
   PRIMARY KEY(`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4;
 
-CREATE INDEX idx_jia_isu_uuid_and_timestamp_desc ON isu_condition (jia_isu_uuid, timestamp DESC);
-CREATE INDEX idx_jia_isu_uuid_and_timestamp ON isu_condition (jia_isu_uuid, timestamp);
+CREATE INDEX idx_jia_isu_uuid_and_timestamp_desc ON isu_condition (jia_isu_uuid, `timestamp` DESC);
+CREATE INDEX idx_jia_isu_uuid_and_timestamp ON isu_condition (jia_isu_uuid, `timestamp`);
 
 
 CREATE TABLE `user` (


### PR DESCRIPTION
```
17:00:09.202651 score: 15246(15248 - 2) : pass
17:00:09.202657 deduction: 0 / timeout: 21
17:00:09.202664 <=== sendResult finish
```

```
sudo cat /var/log/nginx/access.log | ./kataribe -conf kataribe.toml | grep --after-context 20 "Top 20 Sort By Total"
Top 20 Sort By Total
Count    Total    Mean  Stddev    Min  P50.0  P90.0  P95.0  P99.0    Max    2xx  3xx   4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
73570  930.429  0.0126  0.0198  0.000  0.006  0.033  0.061  0.100  0.186  72414    0  1156    0          70          0          0         14  POST /api/condition/[a-z0-9-]+
 6245  258.985  0.0415  0.0383  0.000  0.032  0.080  0.104  0.178  0.690   5922    0   323    0   134500436         14      21537     135259  GET /api/isu/[a-z0-9-]+
 3313  211.441  0.0638  0.0475  0.000  0.052  0.123  0.153  0.224  0.606   2966    0   347    0    16921903          0       5107       7243  GET /api/condition/[a-z0-9-]+
  179  169.006  0.9442  0.2051  0.019  1.000  1.001  1.003  1.007  1.041     13    0   166    0       69332          0        387       8196  GET /api/trend HTTP/2.0
  895   48.525  0.0542  0.0439  0.000  0.045  0.104  0.131  0.215  0.452    677    0   218    0     3259110          0       3641       7697  GET /api/isu/[a-z0-9-]+/graph
  772   44.217  0.0573  0.0371  0.000  0.051  0.100  0.126  0.190  0.238    721    0    51    0     2188344          0       2834      10000  GET /api/isu HTTP/2.0
  707   12.951  0.0183  0.0178  0.000  0.014  0.035  0.045  0.095  0.156    307    0   400    0        4600          0          6         19  POST /api/auth HTTP/2.0
  354    5.034  0.0142  0.0244  0.000  0.007  0.033  0.053  0.098  0.316    157    0   197    0       10079         21         28         45  GET /api/user/me HTTP/2.0
  201    3.783  0.0188  0.0227  0.000  0.011  0.044  0.058  0.079  0.211    149    0    52    0        1092          0          5         21  POST /api/signout HTTP/2.0
   55    3.543  0.0644  0.0219  0.000  0.065  0.083  0.101  0.133  0.133     51    0     4    0        7077         15        128        154  POST /api/isu HTTP/2.0
  391    1.931  0.0049  0.0059  0.000  0.003  0.013  0.017  0.027  0.053    337   54     0    0      177936          0        455        528  GET / HTTP/2.0
  286    1.739  0.0061  0.0067  0.000  0.004  0.014  0.020  0.032  0.054    180  106     0    0   133815060          0     467884     743417  GET /assets/vendor.ee7444dd.js HTTP/2.0
  286    1.594  0.0056  0.0070  0.000  0.003  0.013  0.019  0.035  0.060    180  106     0    0      106560          0        372        592  GET /assets/favicon.d0f5f504.svg HTTP/2.0
  286    1.365  0.0048  0.0066  0.000  0.002  0.013  0.018  0.026  0.066    180  106     0    0      591300          0       2067       3285  GET /assets/logo_white.svg HTTP/2.0
  286    1.257  0.0044  0.0049  0.000  0.003  0.010  0.013  0.023  0.031    180  106     0    0     4800060          0      16783      26667  GET /assets/index.23dac98b.js HTTP/2.0
  286    1.168  0.0041  0.0047  0.000  0.002  0.010  0.013  0.022  0.032    180  106     0    0     3431880          0      11999      19066  GET /assets/index.144d8ca8.css HTTP/2.0
  181    1.027  0.0057  0.0075  0.000  0.003  0.013  0.018  0.034  0.066    179    2     0    0      588552          0       3251       3288  GET /assets/logo_orange.svg HTTP/2.0
    1    0.227  0.2270  0.0000  0.227  0.227  0.227  0.227  0.227  0.227      1    0     0    0          23         23         23         23  POST /initialize HTTP/2.0
   22    0.009  0.0004  0.0005  0.000  0.00
0  0.001  0.001  0.001  0.001     14    8     0    0        7392          0        336        528  GET /isu/[a-z0-9-]+
```


[top-slow.log](https://github.com/cureseven/isucon-practice-20230318/files/11007912/top-slow.log)